### PR TITLE
Add custom client option

### DIFF
--- a/lib/redisstore.js
+++ b/lib/redisstore.js
@@ -34,7 +34,11 @@ function RedisStore(port, host, options) {
 	this._tokenKey = this._options.redisstore.tokenkey || 'pwdless:';
 	delete this._options.redisstore;
 
-	this._client = redis.createClient(port, host, this._options);
+	if(this._options.client){
+		this._client = this._options.client;
+	} else {
+		this._client = redis.createClient(port, host, this._options);
+	}
 }
 
 util.inherits(RedisStore, TokenStore);


### PR DESCRIPTION
If an existing redis client is passed into the options, it will be used instead of creating a new one.